### PR TITLE
Moved @types dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "pusher-platform-node",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "./target/index.js",
   "types": "./target/index.d.ts",
   "dependencies": {
-    "@types/es6-promise": "0.0.32",
-    "@types/extend": "^2.0.0",
-    "@types/jsonwebtoken": "^7.2.0",
     "extend": "^2.0.1",
     "jsonwebtoken": "^7.4.1"
   },
   "devDependencies": {
-    "typescript": "^2.4.1"
+    "typescript": "^2.4.1",
+    "@types/es6-promise": "0.0.32",
+    "@types/extend": "^2.0.0",
+    "@types/jsonwebtoken": "^7.2.0"
   },
   "scripts": {
     "prepublish": "rm -rf target && tsc"


### PR DESCRIPTION
### What?

See title. If targetting ES6 it was blowing up. Possibly also earlier targets.

Fix for https://github.com/pusher/pusher-platform-node/issues/27

----

CC @pusher/sigsdk
