### PR TITLE
Change behaviour of superuser token generator to match other token behaviour

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,9 +3,14 @@ import {IncomingMessage} from "http";
 import {IncomingMessageWithBody} from "./common";
 import * as jwt from "jsonwebtoken";
 
-import Authenticator, { TokenWithExpiry, AuthenticationResponse } from "./authenticator";
+import Authenticator, {
+  TokenWithExpiry, AuthenticationResponse, TOKEN_LEEWAY
+} from "./authenticator";
 import BaseClient from "./base_client";
 import {AuthenticateOptions, RequestOptions} from "./common";
+
+// 5 minutes should be enough for a single sudo request
+const SUPERUSER_TOKEN_EXPIRY = 60*5;
 
 export interface Options {
   cluster: string;
@@ -44,7 +49,7 @@ export default class App {
   request(options: RequestOptions): Promise<IncomingMessage> {
     options = this.scopeRequestOptions("apps", options);
     if (options.jwt == null) {
-      options = extend(options, { jwt: this.generateSuperuserJWT() });
+      options = extend(options, { jwt: this.generateSuperuserJWT().jwt });
     }
     return this.client.request(options);
   }
@@ -63,10 +68,14 @@ export default class App {
       app: this.appId,
       iss: this.appKeyId,
       su: true,
-      iat: now - 30,   // some leeway for the server
-      exp: now + 60*5, // 5 minutes should be enough for a single request
+      iat: now - TOKEN_LEEWAY,
+      exp: now + SUPERUSER_TOKEN_EXPIRY,
     };
-    return jwt.sign(claims, this.appKeySecret);
+
+    return {
+      jwt: jwt.sign(claims, this.appKeySecret),
+      expires_in: SUPERUSER_TOKEN_EXPIRY
+    };
   }
 
   private scopeRequestOptions(prefix: string, options: RequestOptions): RequestOptions {

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -52,7 +52,7 @@ export default class Authenticator {
   private authenticateWithClientCredentials(options: AuthenticateOptions): AuthenticationResponse {
     let {token} = this.generateAccessToken(options);
     let refreshToken = this.generateRefreshToken(options);
-    
+
     return {
       access_token: token,
       token_type: "bearer",


### PR DESCRIPTION
### What?

Make `generateSuperuserJWT` return something in the form of:

```js
{
  jwt: "some-jwt",
  expires_in: 123
}
```

#### Why?

Needed in chatkit-server-node and it generally brings it in line with other token generation conventions in the SDK.

#### How?

Change the return value

---

CC @pusher/sigsdk