### PR TITLE
instance -> instanceID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 ## [v0.8.0] 2017-07-19
 
 ### Changes
-- Renamed the `instance` to `instanceID` when instantiating an `Instance`. `Instance` class now has a parameter `id` that used to be `instance`. 
+- Renamed the `instance` to `instanceId` when instantiating an `Instance`. `Instance` class now has a parameter `id` that used to be `instance`. 
 
 ## [v0.7.1] 2017-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
+## [v0.8.0] 2017-07-19
+
+### Changes
+- Renamed the `instance` to `instanceID` when instantiating an `Instance`. `Instance` class now has a parameter `id` that used to be `instance`. 
+
 ## [v0.7.1] 2017-07-18
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ It takes the following arguments:
 var pusher = require("pusher-platform-node");
 
 var pusherPlatform = new pusher.Instance({
-  instanceID: "",
+  instanceId: "",
   serviceName: "",
   serviceVersion: "",
   key: "",
 });
 ```
 
-`instanceID` is the ID that is unique to app developers' instance - they get that from the dashboard. The service SDKs will need to relay that down. Same for the `key`.
+`instanceId` is the ID that is unique to app developers' instance - they get that from the dashboard. The service SDKs will need to relay that down. Same for the `key`.
 `serviceName` and `serviceVersion` should come from the service SDK itself. They can be hardcoded there. Think `feeds` and `v1`.
 
 It is also possible to specify `host` and `port`. This will override the cluster value that is encoded in the `instance` and allow you to connect to a development or testing server.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add `pusher-platform-node` to your package.json file:
 ```json
 {
   "dependencies": {
-    "pusher-platform-node": "^0.7.1"
+    "pusher-platform-node": "^0.8.0"
   }
 }
 ```
@@ -23,14 +23,14 @@ It takes the following arguments:
 var pusher = require("pusher-platform-node");
 
 var pusherPlatform = new pusher.Instance({
-  instance: "",
+  instanceID: "",
   serviceName: "",
   serviceVersion: "",
   key: "",
 });
 ```
 
-`instance` is the ID that is unique to app developers' instance - they get that from the dashboard. The service SDKs will need to relay that down. Same for the `key`.
+`instanceID` is the ID that is unique to app developers' instance - they get that from the dashboard. The service SDKs will need to relay that down. Same for the `key`.
 `serviceName` and `serviceVersion` should come from the service SDK itself. They can be hardcoded there. Think `feeds` and `v1`.
 
 It is also possible to specify `host` and `port`. This will override the cluster value that is encoded in the `instance` and allow you to connect to a development or testing server.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pusher-platform-node",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "main": "./target/index.js",
   "types": "./target/index.d.ts",
   "dependencies": {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -17,7 +17,7 @@ const HOST_BASE = "pusherplatform.io";
 const HTTPS_PORT = 443;
 
 export interface InstanceOptions {
-  instance: string;
+  instanceID: string;
   key: string;
   serviceName: string;
   serviceVersion: string;
@@ -29,7 +29,7 @@ export interface InstanceOptions {
 
 export default class Instance {
   private client: BaseClient;
-  private instanceId: string;
+  private id: string;
   private serviceName: string;
   private serviceVersion: string;
   private cluster: string;
@@ -43,15 +43,15 @@ export default class Instance {
 
   constructor(options: InstanceOptions) {
 
-    if (!options.instance) throw new Error('Expected `instance` property in Instance options!');
-    if (options.instance.split(":").length !== 3) throw new Error('The instance property is in the wrong format!');
+    if (!options.instanceID) throw new Error('Expected `instance` property in Instance options!');
+    if (options.instanceID.split(":").length !== 3) throw new Error('The instance property is in the wrong format!');
     if(!options.serviceName) throw new Error('Expected `serviceName` property in Instance options!');
     if(!options.serviceVersion) throw new Error('Expected `serviceVersion` property in Instance otpions!');
 
-    let splitInstance = options.instance.split(":");
+    let splitInstance = options.instanceID.split(":");
     this.platformVersion = splitInstance[0];
     this.cluster = splitInstance[1];
-    this.instanceId = splitInstance[2];
+    this.id = splitInstance[2];
 
     this.serviceName = options.serviceName;
     this.serviceVersion = options.serviceVersion;
@@ -65,14 +65,14 @@ export default class Instance {
 
     this.client = options.client || new BaseClient({
       host: options.host || `${this.cluster}.${HOST_BASE}`,
-      instanceId: this.instanceId,
+      instanceId: this.id,
       serviceName: this.serviceName,
       serviceVersion: this.serviceVersion,
       port: options.port || HTTPS_PORT
     });
 
     this.authenticator = new Authenticator(
-      this.instanceId, this.keyId, this.keySecret
+      this.id, this.keyId, this.keySecret
     );
   }
 

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -17,7 +17,7 @@ const HOST_BASE = "pusherplatform.io";
 const HTTPS_PORT = 443;
 
 export interface InstanceOptions {
-  instanceID: string;
+  instanceId: string;
   key: string;
   serviceName: string;
   serviceVersion: string;
@@ -43,12 +43,12 @@ export default class Instance {
 
   constructor(options: InstanceOptions) {
 
-    if (!options.instanceID) throw new Error('Expected `instance` property in Instance options!');
-    if (options.instanceID.split(":").length !== 3) throw new Error('The instance property is in the wrong format!');
+    if (!options.instanceId) throw new Error('Expected `instance` property in Instance options!');
+    if (options.instanceId.split(":").length !== 3) throw new Error('The instance property is in the wrong format!');
     if(!options.serviceName) throw new Error('Expected `serviceName` property in Instance options!');
     if(!options.serviceVersion) throw new Error('Expected `serviceVersion` property in Instance otpions!');
 
-    let splitInstance = options.instanceID.split(":");
+    let splitInstance = options.instanceId.split(":");
     this.platformVersion = splitInstance[0];
     this.cluster = splitInstance[1];
     this.id = splitInstance[2];


### PR DESCRIPTION
### What?

Renamed the instance param to instanceID when instantiating the Instance.
The instance field in the Instance is now called just ID.

#### Why?

It should make things simpler, also on the service level.

### Please make sure to update the README if you changed the API.

----

CC @pusher/sigsdk
