### PR TITLE
Update path sanitisation. Add token interface export

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -10,7 +10,6 @@ const CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
 const REFRESH_TOKEN_GRANT_TYPE = "refresh_token";
 
 export interface TokenWithExpiry {
-
   token: string;
   expires_in: number;
 }

--- a/src/base_client.ts
+++ b/src/base_client.ts
@@ -48,11 +48,13 @@ export default class BaseClient {
       headers["Authorization"] = `Bearer ${options.jwt}`
     }
 
+    const path = this.sanitisePath(`services/${this.serviceName}/${this.serviceVersion}/${this.instanceId}/${options.path}`);
+
     const host = formatURL({
       protocol: 'https',
       hostname: this.host,
       port: this.port,
-      pathname: normalizePath(`services/${this.serviceName}/${this.serviceVersion}/${this.instanceId}/${options.path}`)
+      pathname: normalizePath(path)
     });
 
     return new Promise<IncomingMessageWithBody>((resolve, reject) => {
@@ -81,6 +83,10 @@ export default class BaseClient {
           }
         }
       });
-  });
+    });
+  }
+
+  private sanitisePath(path: string): string {
+    return path.replace(/\/ /g, "/").replace(/\/ $/, "");
   }
 }

--- a/src/base_client.ts
+++ b/src/base_client.ts
@@ -6,7 +6,6 @@ import {
 } from "./common";
 import * as HttpRequest from "request";
 import { format as formatURL } from "url";
-import { normalize as normalizePath } from "path";
 
 export interface BaseClientOptions {
   host: string;
@@ -48,13 +47,13 @@ export default class BaseClient {
       headers["Authorization"] = `Bearer ${options.jwt}`
     }
 
-    const path = this.sanitisePath(`services/${this.serviceName}/${this.serviceVersion}/${this.instanceId}/${options.path}`);
+    const path = this.sanitizePath(`services/${this.serviceName}/${this.serviceVersion}/${this.instanceId}/${options.path}`);
 
     const host = formatURL({
       protocol: 'https',
       hostname: this.host,
       port: this.port,
-      pathname: normalizePath(path)
+      pathname: path
     });
 
     return new Promise<IncomingMessageWithBody>((resolve, reject) => {
@@ -86,7 +85,12 @@ export default class BaseClient {
     });
   }
 
-  private sanitisePath(path: string): string {
-    return path.replace(/\/ /g, "/").replace(/\/ $/, "");
+  //Cleans up the path provided
+  private sanitizePath(path: string): string {
+    return path
+      .replace(/\/ /g, "/") //Replace space after a slash
+      .replace(/ $/, "") //Remove the trailing space
+      .replace(/[\/]{2,}/g, "/") //Multiple slashes are now single slashes
+      .replace(/\/$/, ""); //Remove trailing slash
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,8 @@ export {
 
 export {default as BaseClient} from "./base_client";
 
-export { DEFAULT_TOKEN_LEEWAY, AuthenticationResponse } from "./authenticator";
+export {
+  DEFAULT_TOKEN_LEEWAY,
+  AuthenticationResponse,
+  TokenWithExpiry,
+} from "./authenticator";

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -77,7 +77,6 @@ export default class Instance {
   }
 
   request(options: RequestOptions): Promise<IncomingMessageWithBody> {
-    options = this.scopeRequestOptions(options);
     if (options.jwt == null) {
       options = extend(options, { jwt: `${this.authenticator.generateAccessToken({ su: true }).token}` });
     }
@@ -91,14 +90,4 @@ export default class Instance {
   generateAccessToken(options: AuthenticateOptions): TokenWithExpiry {
     return this.authenticator.generateAccessToken(options);
   }
-
-  private scopeRequestOptions(options: RequestOptions): RequestOptions {
-    let path = options.path
-      .replace(/\/ /g, "/")
-      .replace(/\/ $/, "");
-    return extend(
-      options,
-      { path: path }
-    );
-    }
 }


### PR DESCRIPTION
### What and why?

Make path sanitisation happen at the last possible moment to give it the best chance of producing a valid path.

Also export `TokenWithExpiry` because I didn't want to keep redefining identical interfaces in chatkit-server-node.

#### How?

Take a look

### Please make sure to update the README if you changed the API.

----

CC @pusher/sigsdk