### PR TITLE
token: app -> instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,19 @@
 # Change Log
 
 This project adheres to [Semantic Versioning Scheme](http://semver.org)
-## [v0.11.0] 2018-01-26
-
-### Changes
-
-- Added support for custom token expiry with a `tokenExpiry` key in `AuthenticateOptions`
-- Removed all mention of `tokenLeeway`
 
 ## Unreleased
 
 ### Changes
 
 - Tokens now use `instance` claim instead of `app` claim
+
+## [v0.11.0] 2018-01-26
+
+### Changes
+
+- Added support for custom token expiry with a `tokenExpiry` key in `AuthenticateOptions`
+- Removed all mention of `tokenLeeway`
 
 ## [v0.10.0] 2017-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 - Added support for custom token expiry with a `tokenExpiry` key in `AuthenticateOptions`
 - Removed all mention of `tokenLeeway`
 
+## Unreleased
+
+### Changes
+
+- Tokens now use `instance` claim instead of `app` claim
+
 ## [v0.10.0] 2017-10-27
 
 ### Changes

--- a/examples/auth.js
+++ b/examples/auth.js
@@ -1,10 +1,13 @@
 var express = require('express');
 var bodyParser = require('body-parser');
 
-var PusherApp = require('../lib/index').App;
-var pusher = new PusherApp({
-  appID: process.env.APP_ID,
-  appKey: process.env.APP_KEY,
+var PusherPlatform = require('../target/index');
+
+var pusher = new PusherPlatform.Instance({
+  locator: 'your:instance:locator',
+  key: 'your:key',
+  serviceName: 'yourServiceName',
+  serviceVersion: 'v1'
 });
 
 var app = express();

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -26,9 +26,9 @@ export interface AuthenticationResponse {
 
 export default class Authenticator {
   constructor(
-    private appId: string,
-    private appKeyId: string,
-    private appKeySecret: string,
+    private instanceId: string,
+    private instanceKeyId: string,
+    private instanceKeySecret: string,
 
     //Customise token expiry
     private tokenExpiry?: number,
@@ -68,8 +68,8 @@ export default class Authenticator {
       let tokenExpiry = options.tokenExpiry || this.tokenExpiry;
 
       try {
-        decoded = jwt.verify(oldRefreshToken, this.appKeySecret, {
-          issuer: `keys/${this.appKeyId}`,
+        decoded = jwt.verify(oldRefreshToken, this.instanceKeySecret, {
+          issuer: `keys/${this.instanceKeyId}`,
         });
       } catch (e) {
         let description: string = (e instanceof jwt.TokenExpiredError) ? "refresh token has expired" : "refresh token is invalid";
@@ -100,8 +100,8 @@ export default class Authenticator {
     let tokenExpiry = options.tokenExpiry || this.tokenExpiry;
 
     let claims = {
-      app: this.appId,
-      iss: `api_keys/${this.appKeyId}`,
+      instance: this.instanceId,
+      iss: `api_keys/${this.instanceKeyId}`,
       iat: now,
       exp: now + tokenExpiry,
       sub: options.userId,
@@ -110,7 +110,7 @@ export default class Authenticator {
     };
 
     return {
-      token: jwt.sign(claims, this.appKeySecret),
+      token: jwt.sign(claims, this.instanceKeySecret),
       expires_in: tokenExpiry,
     };
   }
@@ -119,15 +119,15 @@ export default class Authenticator {
     let now = Math.floor(Date.now() / 1000);
 
     let claims = {
-      app: this.appId,
-      iss: `api_keys/${this.appKeyId}`,
+      instance: this.instanceId,
+      iss: `api_keys/${this.instanceKeyId}`,
       iat: now,
       refresh: true,
       sub: options.userId,
     };
 
     return {
-      token: jwt.sign(claims, this.appKeySecret),
+      token: jwt.sign(claims, this.instanceKeySecret),
     };
   }
 }


### PR DESCRIPTION
Migrates to using the `instance` claim instead of the `app` claim in tokens, and also cleans up any remaining references to app IDs, and fixes the auth example.

----

CC @pusher/sigsdk
