### PR TITLE
Allow custom leeway and expiry for tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ var pusherPlatform = new pusher.Instance({
 
 It is also possible to specify `host` and `port`. This will override the cluster value that is encoded in the `instance` and allow you to connect to a development or testing server.
 
-### Authetication
+### Authentication
 
 Instance objects provide an `authenticate` method, which can be used in controllers
 to build authentication endpoints. Authentication endpoints issue access tokens
@@ -80,6 +80,20 @@ let = authResponse: {
   expires_in: 20000;
   refresh_token: 'cvbccvbb'
 }
+```
+
+Custom `tokenExpiry` and `tokenLeeway` values can be set by including the relevant keys in the `authOptions` object.
+
+```
+let authOptions = {
+  userId: 'zan',
+  serviceClaims: {
+    claim1: 'sdsdsd'
+    ...
+  }
+  tokenExpiry: (10 * 60),
+  tokenLeeway: (5 * 60)
+};
 ```
 
 ### Request API

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ let = authResponse: {
 }
 ```
 
-Custom `tokenExpiry` and `tokenLeeway` values can be set by including the relevant keys in the `authOptions` object.
+A custom token expiry value can be set by including a `tokenExpiry` key in the `authOptions` object.
 
 ```
 let authOptions = {
@@ -92,7 +92,6 @@ let authOptions = {
     ...
   }
   tokenExpiry: (10 * 60),
-  tokenLeeway: (5 * 60)
 };
 ```
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -27,6 +27,8 @@ export interface AuthenticateOptions {
   userId?: string;
   serviceClaims?: any;
   su?: boolean
+  tokenExpiry?: number;
+  tokenLeeway?: number;
 }
 
 export interface AuthenticatePayload {

--- a/src/common.ts
+++ b/src/common.ts
@@ -28,7 +28,6 @@ export interface AuthenticateOptions {
   serviceClaims?: any;
   su?: boolean
   tokenExpiry?: number;
-  tokenLeeway?: number;
 }
 
 export interface AuthenticatePayload {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ export {
 export {default as BaseClient} from "./base_client";
 
 export {
-  DEFAULT_TOKEN_LEEWAY,
   AuthenticationResponse,
   TokenWithExpiry,
 } from "./authenticator";

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -3,7 +3,7 @@ import {IncomingMessage} from "http";
 import * as jwt from "jsonwebtoken";
 
 import Authenticator, {
-  TokenWithExpiry, AuthenticationResponse, DEFAULT_TOKEN_LEEWAY
+  TokenWithExpiry, AuthenticationResponse
 } from "./authenticator";
 import BaseClient from "./base_client";
 import {


### PR DESCRIPTION
### What?
- Allow custom expiry for tokens generated with the `instance.authenticate` method
- Remove all mention of leeway

### Why?
- At present there is no way to set custom expiry and textsync-server-node needs it
- SDKs should not care about leeway

### How?
Extend the `authenticateOptions` type and `authenticator` methods to allow overwriting the defaults.
`tokenExpiry` should never be 0 so falsey check makes sense to me. 


----

- [x] README updated if you changed the API?

----

CC @pusher/sigsdk
