### PR TITLE
Make grant type required

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Make sure you authenticate the user before issuing access tokens.
 
 ```js
 type AuthenticatePayload {
-  grant_type?: string;
+  grant_type: string;
   refresh_token?: string;
 };
 ```

--- a/src/common.ts
+++ b/src/common.ts
@@ -31,7 +31,7 @@ export interface AuthenticateOptions {
 }
 
 export interface AuthenticatePayload {
-  grant_type?: string;
+  grant_type: string;
   refresh_token?: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,24 @@
-export {IncomingMessage as IncomingMessage} from "http";
+export { IncomingMessage as IncomingMessage } from 'http';
 
-export {ErrorResponse, AuthenticateOptions} from "./common";
-export {UnsupportedGrantTypeError, InvalidGrantTypeError} from './errors';
+export {
+  AuthenticateOptions,
+  AuthenticatePayload,
+  ErrorResponse,
+} from './common';
+
+export {
+  InvalidGrantTypeError,
+  UnsupportedGrantTypeError,
+} from './errors';
 
 export {
   default as Instance,
   InstanceOptions
-} from "./instance";
+} from './instance';
 
-export {default as BaseClient} from "./base_client";
+export { default as BaseClient } from './base_client';
 
 export {
   AuthenticationResponse,
   TokenWithExpiry,
-} from "./authenticator";
+} from './authenticator';


### PR DESCRIPTION
### What?

As the title says

### Why?

It's always required otherwise we throw an error

----

- [x] README updated if you changed the API?

----

CC @pusher/sigsdk
