### PR TITLE
Support the `useQuerystring` option to pass to request library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/pusher-platform-node/compare/0.13.0...HEAD)
+## [Unreleased](https://github.com/pusher/pusher-platform-node/compare/0.13.1...HEAD)
+
+## [0.13.1](https://github.com/pusher/pusher-platform-node/compare/0.13.1...0.13.0) - 2018-08-15
+
+### Additions
+
+- `RequestOption` now exposes a `useQuerystring` attribute that can be used to specify if
+  `query-string` library should be used to parse query string.
 
 ## [0.13.0](https://github.com/pusher/pusher-platform-node/compare/0.12.1...0.13.0) - 2018-04-19
 

--- a/src/base_client.ts
+++ b/src/base_client.ts
@@ -61,7 +61,8 @@ export default class BaseClient {
         body: JSON.stringify(options.body),
         headers: headers,
         method: options.method,
-        qs: options.qs
+        qs: options.qs,
+        useQuerystring: options.useQuerystring
       }, (error, response, body) => {
         if(error) {
           reject(error);

--- a/src/common.ts
+++ b/src/common.ts
@@ -62,6 +62,7 @@ export interface RequestOptions {
   headers?: Headers;
   body?: any;
   qs?: object;
+  useQuerystring: boolean;
 }
 
 export interface AuthenticateOptions {


### PR DESCRIPTION
### What?

It allows serialisation and parsing of query strings using the `querystring` library, when set to `true`. 

### Why?

We'd like to use repeated query string parameters to support arrays in chatkit. Eg: foo=1&foo=2.


----

- [ ] README updated if you changed the API?

----

CC @pusher/sigsdk