### PR TITLE
Don't auto-generate a JWT with su: true claim if no JWT provided to Instance.request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/pusher-platform-node/compare/0.13.2...HEAD)
 
+### Changes
+
+- Removed defaulting to generating a JWT with the `su: true` claim if no JWT is provided to a call to `request`
+
 ## [0.13.2](https://github.com/pusher/pusher-platform-node/compare/0.13.1...0.13.2) - 2018-08-17
 
 ### Additions

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -42,7 +42,6 @@ export default class Instance {
   private authenticator: Authenticator;
 
   constructor(options: InstanceOptions) {
-
     if (!options.locator) throw new Error('Expected `instanceLocator` property in Instance options!');
     if (options.locator.split(":").length !== 3) throw new Error('The `locator` property is in the wrong format!');
     if(!options.serviceName) throw new Error('Expected `serviceName` property in Instance options!');
@@ -77,9 +76,6 @@ export default class Instance {
   }
 
   request(options: RequestOptions): Promise<IncomingMessageWithBody> {
-    if (options.jwt == null) {
-      options = extend(options, { jwt: `${this.authenticator.generateAccessToken({ su: true }).token}` });
-    }
     return this.client.request(options);
   }
 


### PR DESCRIPTION
### What?

See title

### Why?

Shouldn't auto-generate tokens, especially not with `su: true` claim

----

- [ ] README updated if you changed the API?

----

CC @pusher/sigsdk