### PR TITLE
remove unnecessary use of extend package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,11 @@
   "main": "target/index.js",
   "types": "target/index.d.ts",
   "dependencies": {
-    "extend": "^2.0.1",
     "jsonwebtoken": "^8.3.0",
     "request": "^2.88.0"
   },
   "devDependencies": {
     "@types/es6-promise": "0.0.32",
-    "@types/extend": "^2.0.0",
     "@types/jsonwebtoken": "^7.2.8",
     "@types/request": "^0.0.45",
     "typescript": "^3.0.3"

--- a/src/base_client.ts
+++ b/src/base_client.ts
@@ -1,4 +1,3 @@
-import extend = require('extend');
 import { IncomingMessage } from 'http';
 import * as https from 'https';
 import * as HttpRequest from 'request';
@@ -75,7 +74,7 @@ export default class BaseClient {
           let statusCode = response.statusCode;
 
           if(statusCode >= 200 && statusCode <= 299) {
-            response = extend(response, { body });
+            response.body = body;
             resolve(response);
           }
           else if (statusCode >= 300 && statusCode <= 399) {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1,4 +1,3 @@
-import extend = require('extend');
 import { IncomingMessage } from 'http';
 import * as jwt from 'jsonwebtoken';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,11 +7,6 @@
   resolved "https://registry.yarnpkg.com/@types/es6-promise/-/es6-promise-0.0.32.tgz#3bcf44fb1e429f3df76188c8c6d874463ba371fd"
   integrity sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=
 
-"@types/extend@^2.0.0":
-  version "2.0.30"
-  resolved "https://registry.yarnpkg.com/@types/extend/-/extend-2.0.30.tgz#58cc93f621d0a358d3fec9bd6e739bc60ec7e275"
-  integrity sha1-WMyT9iHQo1jT/sm9bnObxg7H4nU=
-
 "@types/form-data@*":
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-0.0.33.tgz#c9ac85b2a5fd18435b8c85d9ecb50e6d6c893ff8"
@@ -128,11 +123,6 @@ ecdsa-sig-formatter@1.0.10:
   integrity sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=
   dependencies:
     safe-buffer "^5.0.1"
-
-extend@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-2.0.1.tgz#1ee8010689e7395ff9448241c98652bc759a8260"
-  integrity sha1-HugBBonnOV/5RIJByYZSvHWagmA=
 
 extend@~3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Apparently it has a vulnerability in it but we're not really using it for anything anyway... (and if we were we would just use object spread which is built in to typescript and does the same thing.)

----

CC @pusher/sigsdk
