### PR TITLE
set keep-alive to forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/pusher-platform-node/compare/0.15.3...HEAD)
 
+- Set connection keep-alive to forever.
+
 ## [0.15.3](https://github.com/pusher/pusher-platform-node/compare/0.15.2...0.15.3)
 
 - Remove unnecessary use of extend package

--- a/src/base_client.ts
+++ b/src/base_client.ts
@@ -65,7 +65,8 @@ export default class BaseClient {
         headers: headers,
         method: options.method,
         qs: options.qs,
-        useQuerystring: options.useQuerystring || false
+        useQuerystring: options.useQuerystring || false,
+        forever: true
       }, (error, response, body) => {
         if(error) {
           reject(error);


### PR DESCRIPTION
### What?

Set HTTP connections to stay alive forever.

### Why?

We were paying the cost of the TLS handshake for every request.

Tested with the following snippet:


```js
function go() {
  const start = Date.now()
  chatkit
    .getUsers()
    .then(() => {
      console.log(Date.now() - start)
      go()
    })
    .catch(console.error)
}

go()
```

Before:

```
$ node main.js
403
351
358
359
341
351
262
352
381
274
360
345
```

After:

```
$ node main.js
388
111
107
101
103
102
104
95
94
98
93
100
95
95
96
```

----

- [x] README updated if you changed the API?

----

CC @pusher/sigsdk
