### PR TITLE
Wraps JSON.parse in try/catch

### DIFF
--- a/src/base_client.ts
+++ b/src/base_client.ts
@@ -82,8 +82,18 @@ export default class BaseClient {
             reject(new Error(`Unsupported Redirect Response: ${statusCode}`));
           }
           else if (statusCode >= 400 && statusCode <= 599) {
-            const errJson = JSON.parse(body);
             const { statusCode, headers } = response;
+
+            let errJson;
+            try {
+              errJson = JSON.parse(body);
+            } catch (_) {
+              return reject(new ErrorResponse({
+                error: 'Something went wrong, but could not parse the response',
+                error_description: '',
+                status: statusCode
+              }));
+            }
             const { error, error_description, error_uri } = errJson;
             reject(new ErrorResponse({
               error,


### PR DESCRIPTION
### What?
Wraps JSON.parse in try/catch


### Why?
To protect against non-JSON responses, which would cause the app to crash

----

- [ ] README updated if you changed the API?

----

CC @pusher/sigsdk
